### PR TITLE
Some tweaks

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -7,6 +7,7 @@ KVER ?= $(shell uname -r)
 PWD  := $(shell pwd)
 
 CFLAGS_lg_magic_airmouse.o += $(CC_FLAGS_FPU)
+ccflags-remove-y += -mgeneral-regs-only
 
 all:
 	$(MAKE) -C $(KDIR) M=$(PWD) modules

--- a/kernel/lg_magic_main.c
+++ b/kernel/lg_magic_main.c
@@ -283,6 +283,7 @@ loaded:
 	drvdata->input_hid->id.product = hdev->product;
 
 	set_bit(EV_KEY, drvdata->input_hid->evbit);
+	set_bit(EV_REP, drvdata->input_hid->evbit);
 	set_bit(EV_REL, drvdata->input_hid->evbit);
 	set_bit(REL_WHEEL, drvdata->input_hid->relbit);
 	set_bit(REL_X, drvdata->input_hid->relbit);

--- a/kernel/lg_magic_main.c
+++ b/kernel/lg_magic_main.c
@@ -66,7 +66,7 @@ static const struct {
 	u16 code;
 	u16 keycode;
 } lg_btn_map[] = {
-	{ 0x8000, KEY_POWER },
+	//{ 0x????, KEY_POWER }, On LG's AN-MR19BA the power button is strictly an IR button?
 	{ 0x8099, KEY_SLEEP },
 	{ 0x8010, KEY_0 }, { 0x8011, KEY_1 }, { 0x8012, KEY_2 },
 	{ 0x8013, KEY_3 }, { 0x8014, KEY_4 }, { 0x8015, KEY_5 },
@@ -86,7 +86,7 @@ static const struct {
 	{ 0x805D, KEY_MEDIA }, // IVI
 	{ 0x800B, KEY_TV },
 	{ 0x8098, KEY_CONTEXT_MENU }, // STB MENU
-	//{ 0x8000, KEY_CHANNELUP }, // Somehow it collides with power button
+	{ 0x8000, KEY_CHANNELUP },
 	{ 0x8001, KEY_CHANNELDOWN },
 	{ 0x8072, KEY_RED },
 	{ 0x8071, KEY_GREEN },

--- a/kernel/lg_magic_main.c
+++ b/kernel/lg_magic_main.c
@@ -81,6 +81,7 @@ static const struct {
 	{ 0x808B, KEY_VOICECOMMAND },
 	{ 0x807C, KEY_HOME },
 	{ 0x8043, KEY_SETUP },
+	{ 0x804C, KEY_LIST }, // List button on MR19
 	{ 0x8028, KEY_BACK },
 	{ 0x80AB, KEY_PROGRAM },
 	{ 0x805D, KEY_MEDIA }, // IVI


### PR DESCRIPTION
Nice project!

It seems to work with my LG Magic Remote model AN-MR19BA.

Changes in this pull request:

Set the EV_REP bit so that repeat is enabled by kernel when pressing buttons.

Removes the general-regs-only  from ccflags to allow floating point compilation on Raspberry Pi. I don't know why the CC_FLAGS_FPU flag in the line above isn't sufficient.

Changes the 0x8000 code to be the channel up key and not the power key. I have a theory about the power key that explains why it is weird. At least on my remote, the power key does not generate any kind of BLE key event. Instead, it is the only button that transmits IR from the front of the remote. My suspicion is that this is to make the onboarding process for the remote more or less bullet proof. LG's instructions to pair a remote with the TV require turning on the TV, pointing the remote at the TV, and then pressing the designated pairing button on the remote. The IR only power button ensures that the TV can always be powered on with the remote, even if they are not paired. Incidentally, the remote transmits IR on all buttons when unpaired. This may explain the instruction the point the remote at the TV when pairing. Perhaps, the IR is used to signal to the TV to start the pairing process on the TV.

Later remotes may issue a key press event in addition to the IR. On the AN-MR19BA there is no power button event, so I set the code to the channel up key which I think is also generally less surprising (I was very surprised when the channel up button caused a shutdown). 
